### PR TITLE
feat: Add button to copy all tags from stats page

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,12 +95,14 @@
                     <ul id="modalStatsTagFrequencyList">
                         <!-- Tag frequencies will be populated here -->
                     </ul>
+                    <button id="copyAllTagsButton" class="app-button">Copy All Tags</button>
                 </div>
             </div>
         </div>
     </div>
 
     <div id="dragGhost" style="position: absolute; visibility: hidden; pointer-events: none;"></div>
+    <div id="toastNotification"></div>
     <script src="/script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -37,6 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const modalConfirmNoButton = document.getElementById('modalConfirmNoButton');
     const size512Button = document.getElementById('size512Button'); // Keep for downscaleButton
     const size1024Button = document.getElementById('size1024Button'); // Keep for downscaleButton
+    const toastNotification = document.getElementById('toastNotification');
 
     let selectedSize = 512; // Default size, used by Downscale to Target
     let currentProjectServerPath = '';
@@ -52,6 +53,23 @@ document.addEventListener('DOMContentLoaded', () => {
     let globalTagsSet = new Set();
     const API_BASE_URL = '/api';
     let draggedTagElement = null;
+
+    let toastTimeout; // Variable to hold the timeout ID for the toast
+
+    function showToast(message) {
+        if (!toastNotification) return;
+        toastNotification.textContent = message;
+        toastNotification.classList.add('show');
+
+        // Clear any existing timeout to prevent premature hiding
+        if (toastTimeout) {
+            clearTimeout(toastTimeout);
+        }
+
+        toastTimeout = setTimeout(() => {
+            toastNotification.classList.remove('show');
+        }, 3000);
+    }
 
     function logMessage(message, type = 'info') {
         const prefix = `[${new Date().toLocaleTimeString()}]`;
@@ -537,6 +555,25 @@ document.addEventListener('DOMContentLoaded', () => {
         modalConfirmationView.style.display = 'none';
         modalStatsView.style.display = 'block';
         logMessage("Statistics view displayed in modal.");
+
+        const copyAllTagsButton = document.getElementById('copyAllTagsButton');
+        if (copyAllTagsButton) {
+            copyAllTagsButton.addEventListener('click', async () => {
+                const tagsToCopy = Object.keys(tagFrequencies);
+                if (tagsToCopy.length > 0) {
+                    const tagsString = tagsToCopy.join(', ');
+                    try {
+                        await navigator.clipboard.writeText(tagsString);
+                        showToast('Tags copied to clipboard!');
+                    } catch (err) {
+                        showToast('Error copying tags.');
+                        console.error('Clipboard error:', err);
+                    }
+                } else {
+                    showToast('No tags to copy.');
+                }
+            });
+        }
     }
 
     // --- Image Processing Feature Logic ---

--- a/style.css
+++ b/style.css
@@ -155,6 +155,18 @@ body, html {
 #downscaleButton:hover {
     background-color: #1e7e34;
 }
+
+#copyAllTagsButton {
+    background-color: #007bff; /* Standard blue */
+    margin-top: 15px;
+    /* Ensure it takes full width or aligns nicely if that's the design for modal buttons */
+    /* display: block; /* Uncomment if it should be block-level */
+    /* width: 100%;  /* Uncomment if it should span full width */
+}
+
+#copyAllTagsButton:hover {
+    background-color: #0056b3; /* Darker blue on hover */
+}
 /* End of new styles for fill image feature / app-buttons */
 
 .application-section-header {
@@ -433,3 +445,24 @@ body, html {
     border-radius: 3px;
 }
 */
+
+/* Toast Notification Styles */
+#toastNotification {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #333;
+    color: white;
+    padding: 15px 25px;
+    border-radius: 5px;
+    z-index: 1000;
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.5s, visibility 0.5s;
+}
+
+#toastNotification.show {
+    visibility: visible;
+    opacity: 1;
+}


### PR DESCRIPTION
This commit introduces a new "Copy All Tags" button on the statistics modal.

When clicked, this button:
- Gathers all unique tags displayed in the tag frequency list.
- Formats them into a single, comma-separated string (e.g., "tag1, tag_2, tag_whatever").
- Copies this string to your clipboard.
- Displays a toast notification to confirm that the tags have been copied or to indicate an error if the copy operation fails.

The button has been styled to match the existing application theme, and the toast notification provides non-intrusive feedback to you.